### PR TITLE
indexOf for comments

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -69,7 +69,8 @@ function Cobol(input, options, callback) {
     // Comment
     // TODO We should improve this.
     if (typeof input === "function") {
-        input = input.toString().slice(17, -4)
+        input = input.toString();
+        input = input.slice(input.indexOf("/*") + 2, input.indexOf("*/"));
     }
 
     // Code


### PR DESCRIPTION
This makes it so that you don't have to have the exact same function declaration style for your function that contains a cobol comment as that listed in the documentation, so you can write a function like this and still have it work:

```
function(Woah, This, Is, A, Bunch, Of, Args) {



/*
    COBOL HERE
*/
}
```
