### PR TITLE
Allow linking to a library by specifying an 'l' option.

### DIFF
--- a/lib/compile/index.js
+++ b/lib/compile/index.js
@@ -49,6 +49,7 @@ function Compile(input, options, callback) {
         if (options.free) {
             args.free = options.free;
         }
+
 	if(options.l) {
 	    args.l = options.l;
 	}

--- a/lib/compile/index.js
+++ b/lib/compile/index.js
@@ -49,6 +49,9 @@ function Compile(input, options, callback) {
         if (options.free) {
             args.free = options.free;
         }
+	if(options.l) {
+	    args.l = options.l;
+	}
 
         Exec(OArgv(args, "cobc"), {
             cwd: options.cwd


### PR DESCRIPTION
My current usecase for this is linking to libpq (postgresql) which allows for embedded calls to postgres from the COBOL programs :-)

I would have like to enable linking to multiple libs by passing in an array, and it looks to me like OArgv should be able to handle it, but it doesn't work and I haven't yet had a chance to dig any further.
