### PR TITLE
Added precompiled flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,9 @@ Runs COBOL code from Node.JS side.
  - `stdin` (Stream): An optional stdin stream used to pipe data to the stdin stream of the COBOL process.
  - `stderr` (Stream): An optional stderr stream used to pipe data to the stdin stream of the COBOL process.
  - `stdeout` (Stream): An optional stdout stream used to pipe data to the stdin stream of the COBOL process.
-- **Function** `callback`: The callback function called with `err`, `stdout` and `stderr`.
+ - `remove` (Boolean): Should the compiled executable be removed after running, default is true.
+ - `precompiled` (Boolean): Run the precompiled executable instead of re-compiling, default is false.
+ - **Function** `callback`: The callback function called with `err`, `stdout` and `stderr`.
 
 
 

--- a/lib/compile/index.js
+++ b/lib/compile/index.js
@@ -37,8 +37,10 @@ function CheckCobc(callback) {
  * @param {Function} callback The callback function.
  */
 function Compile(input, options, callback) {
+
+    var output = Path.join(options.cwd, Path.basename(input).slice(0, -4));
+
     if (options.precompiled) {
-      var output = Path.join(options.cwd, Path.basename(input).slice(0, -4));
       callback(null, output);
     } else {
       CheckCobc(function (exists) {
@@ -60,7 +62,6 @@ function Compile(input, options, callback) {
               if (stderr || err) {
                   return callback(stderr || err);
               }
-              var output = Path.join(options.cwd, Path.basename(input).slice(0, -4));
               callback(null, output);
           });
       });

--- a/lib/compile/index.js
+++ b/lib/compile/index.js
@@ -37,33 +37,34 @@ function CheckCobc(callback) {
  * @param {Function} callback The callback function.
  */
 function Compile(input, options, callback) {
-    CheckCobc(function (exists) {
-        if (!exists) {
-            return callback(new Error("Couldn't find the cobc executable in the PATH. Make sure you installed Open Cobol."));
-        }
+    if (options.precompiled) {
+      var output = Path.join(options.cwd, Path.basename(input).slice(0, -4));
+      callback(null, output);
+    } else {
+      CheckCobc(function (exists) {
+          if (!exists) {
+              return callback(new Error("Couldn't find the cobc executable in the PATH. Make sure you installed Open Cobol."));
+          }
 
-        var args = {
-            x: true
-          , _: input
-        };
-        if (options.free) {
-            args.free = options.free;
-        }
+          var args = {
+              x: true
+            , _: input
+          };
+          if (options.free) {
+              args.free = options.free;
+          }
 
-        if (options.l) {
-            args.l = options.l;
-        }
-
-        Exec(OArgv(args, "cobc"), {
-            cwd: options.cwd
-        }, function (err, stdout, stderr) {
-            if (stderr || err) {
-                return callback(stderr || err);
-            }
-            var output = Path.join(options.cwd, Path.basename(input).slice(0, -4));
-            callback(null, output);
-        })
-    });
+          Exec(OArgv(args, "cobc"), {
+              cwd: options.cwd
+          }, function (err, stdout, stderr) {
+              if (stderr || err) {
+                  return callback(stderr || err);
+              }
+              var output = Path.join(options.cwd, Path.basename(input).slice(0, -4));
+              callback(null, output);
+          })
+      });
+    }
 }
 
 module.exports = Compile;

--- a/lib/compile/index.js
+++ b/lib/compile/index.js
@@ -62,7 +62,7 @@ function Compile(input, options, callback) {
               }
               var output = Path.join(options.cwd, Path.basename(input).slice(0, -4));
               callback(null, output);
-          })
+          });
       });
     }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,6 +25,8 @@ var Spawn = require("child_process").spawn
  *  - `stdin` (Stream): An optional stdin stream used to pipe data to the stdin stream of the COBOL process.
  *  - `stderr` (Stream): An optional stderr stream used to pipe data to the stdin stream of the COBOL process.
  *  - `stdeout` (Stream): An optional stdout stream used to pipe data to the stdin stream of the COBOL process.
+ *  - `remove` (Boolean): Should the compiled executable be removed after running, default is true.
+ *  - `precompiled` (Boolean): Run the precompiled executable instead of re-compiling, default is false.
  *
  * @param {Function} callback The callback function called with `err`, `stdout` and `stderr`.
  */


### PR DESCRIPTION
Added precompiled flag to allow for the running of compiled cobol code.

Pre-compiling significantly lowers the response time when used in for example a webservice.
