### PR TITLE
Arbitrary compiler options

### DIFF
--- a/examples/index.js
+++ b/examples/index.js
@@ -14,7 +14,7 @@ Cobol(function () {/*
                    DISPLAY "Hello world".
                    PROGRAM-DONE.
                    STOP RUN.
-                   */}, function (err, data) {
+                   */}, {compileargs:{free:true}}, function (err, data) {
     console.log(err || data);
 });
 // => "Hello World"

--- a/examples/index.js
+++ b/examples/index.js
@@ -14,7 +14,11 @@ Cobol(function () {/*
                    DISPLAY "Hello world".
                    PROGRAM-DONE.
                    STOP RUN.
-                   */}, {compileargs:{free:true}}, function (err, data) {
+                   */}, {
+                       compileargs:{
+                           free:true
+                        }
+                    }, function (err, data) {
     console.log(err || data);
 });
 // => "Hello World"

--- a/lib/compile/index.js
+++ b/lib/compile/index.js
@@ -53,9 +53,7 @@ function Compile(input, options, callback) {
                 x: true,
                 _: input
             };
-            if (options.free) {
-                args.free = options.free;
-            }
+            Object.assign(args, options.compileargs);
 
             Exec(OArgv(args, "cobc"), {
                 cwd: options.cwd

--- a/lib/index.js
+++ b/lib/index.js
@@ -24,7 +24,7 @@ var Spawn = require("child_process").spawn,
  *
  *  - `cwd` (String): Where the COBOL code will run (by default in the current working directory)
  *  - `args` (Array): An array of strings to pass to the COBOL process.
- *  - `free` (Boolean): Use free option while compiling with GnuCobol
+ *  - `compileargs` (Object): Use to specificy cobc compiler options
  *  - `stdin` (Stream): An optional stdin stream used to pipe data to the stdin stream of the COBOL process.
  *  - `stderr` (Stream): An optional stderr stream used to pipe data to the stdin stream of the COBOL process.
  *  - `stdeout` (Stream): An optional stdout stream used to pipe data to the stdin stream of the COBOL process.
@@ -47,7 +47,7 @@ function Cobol(input, options, callback) {
     // Merge the defaults
     options = Ul.merge(options, {
         cwd: process.cwd(),
-        free: false,
+        compileargs: {},
         args: []
     });
 

--- a/lib/run/index.js
+++ b/lib/run/index.js
@@ -20,7 +20,7 @@ function Run(path, options, callback) {
         data = "";
 
     if (options.remove !== false) {
-        Fs.unlink(path);
+        Fs.unlink(path, () => {});
     }
 
     if (options.stdin) {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   ],
   "author": "Ionică Bizău <bizauionica@gmail.com> (https://ionicabizau.net)",
   "contributors": [
-    "Krzysztof Kaczor <krzkaczor@gmail.com> (http://kaczor.io)"
+    "Krzysztof Kaczor <krzkaczor@gmail.com> (http://kaczor.io)",
+    "Arnar Hardarson <arnar_hardarson@hotmail.com>"
   ],
   "license": "MIT",
   "blah": {


### PR DESCRIPTION
Added a compiler options object that will be passed to the compiler, to enhance the thing in issue #39.

This should allow the user to specific whatever options there are in the cobc as required. I've added the free flag in the `Hello world` example to show the intended change.

As a small side change i also made was adding a callback to the Fs.unlink as it was giving deprecation errors :).  Currently the callback does nothing.